### PR TITLE
Move the 'Clear Dewar' button into the Dewar Report card

### DIFF
--- a/client/src/components/ClearLocationDialog.vue
+++ b/client/src/components/ClearLocationDialog.vue
@@ -17,7 +17,7 @@ Emits an event 'confirm-removal' with a boolean true/false if user confirmed act
             <h1 class="text-xl">Confirm Clear</h1>
             </header>
         <section class="p-4">
-          <p>Confirm removal of dewar from location {{locationToRemove}}?</p>
+          <p>Confirm removal of dewar {{barcodeToRemove}}?</p>
         </section>
         <footer class="flex border-t-2">
           <button class="w-1/2 text-white bg-success hover:bg-green-700 rounded p-1 m-2" v-on:click="onConfirm()">Confirm</button>
@@ -31,18 +31,24 @@ Emits an event 'confirm-removal' with a boolean true/false if user confirmed act
 <script>
 export default {
     name: 'ClearLocationDialog',
-    props: ['isActive', 'locationToRemove', 'rack_locations'],
+    props: ['isActive', 'barcodeToRemove', 'rack_locations'],
     methods: {
         // User has confirmed to remove the dewar from this location
         onConfirm: function() {
             // Extra check to ensure this is a valid location
-            let hasLocation = this.rack_locations.hasOwnProperty(this.locationToRemove)
+            let hasLocation = this.rack_locations.hasOwnProperty(this.barcodeToRemove)
 
             if (hasLocation) {
                 // Store variables for use within axios handler functions
                 let self = this
-                let location = this.locationToRemove
-                let barcode = this.rack_locations[location]['barcode']
+                let barcode = this.barcodeToRemove
+                let location = ""
+                for (loc in this.rack_locations) {
+                    if (this.rack_locations[loc]['barcode'] == barcode) {
+                        location = loc
+                        break
+                    }
+                }
                 let url = this.$store.state.apiRoot + "dewars/locations"
 
                 this.$http.delete(url, {params: {'location': location}})

--- a/client/src/components/ClearLocationDialog.vue
+++ b/client/src/components/ClearLocationDialog.vue
@@ -40,6 +40,7 @@ export default {
             let self = this
             let barcode = this.barcodeToRemove
             let location = ""
+            let loc = ""
             for (loc in this.rack_locations) {
                 if (this.rack_locations[loc]['barcode'] == barcode) {
                     location = loc

--- a/client/src/components/ClearLocationDialog.vue
+++ b/client/src/components/ClearLocationDialog.vue
@@ -35,36 +35,33 @@ export default {
     methods: {
         // User has confirmed to remove the dewar from this location
         onConfirm: function() {
-            // Extra check to ensure this is a valid location
-            let hasLocation = this.rack_locations.hasOwnProperty(this.barcodeToRemove)
 
-            if (hasLocation) {
-                // Store variables for use within axios handler functions
-                let self = this
-                let barcode = this.barcodeToRemove
-                let location = ""
-                for (loc in this.rack_locations) {
-                    if (this.rack_locations[loc]['barcode'] == barcode) {
-                        location = loc
-                        break
-                    }
+            // Store variables for use within axios handler functions
+            let self = this
+            let barcode = this.barcodeToRemove
+            let location = ""
+            for (loc in this.rack_locations) {
+                if (this.rack_locations[loc]['barcode'] == barcode) {
+                    location = loc
+                    break
                 }
-                let url = this.$store.state.apiRoot + "dewars/locations"
-
-                this.$http.delete(url, {params: {'location': location}})
-                .then(function(response) {
-                    console.log(response)
-                    let message = "Removing dewar " + barcode + " from location " + location + "..."
-
-                    self.$store.dispatch("updateMessage", {text: message, isError: false})
-                })
-                .catch(function() {
-                    console.log("Error removing dewar")
-                    let message = "Error removing dewar " + barcode + " from location " + location
-
-                    self.$store.dispatch("updateMessage", {text: message, isError: true})
-                })
             }
+            let url = this.$store.state.apiRoot + "dewars/locations"
+
+            this.$http.delete(url, {params: {'location': location}})
+            .then(function(response) {
+                console.log(response)
+                let message = "Removing dewar " + barcode + " from location " + location + "..."
+
+                self.$store.dispatch("updateMessage", {text: message, isError: false})
+            })
+            .catch(function() {
+                console.log("Error removing dewar")
+                let message = "Error removing dewar " + barcode + " from location " + location
+
+                self.$store.dispatch("updateMessage", {text: message, isError: true})
+            })
+
             this.$emit("confirm-removal", true)
         },
         // User has cancelled        

--- a/client/src/components/DewarCard.vue
+++ b/client/src/components/DewarCard.vue
@@ -18,7 +18,6 @@ Emits an event 'clear-location' which should be handled by the parent component
         </div>
         <div v-if="dewar.barcode" class="flex justify-between mt-2 pt-2 border-t border-gray-400">
             <button @click.prevent="showDewarReport(dewar)" class="rounded text-sm text-gray-200 bg-green-500 hover:bg-green-700 px-2 py-1"><i :class="[buttonClass, 'pr-2']"></i>{{ buttonLabel }}</button>
-            <button @click.prevent="clearLocation(rack)" class="rounded text-sm text-gray-200 bg-red-500 hover:bg-red-700 px-2 py-1"><i class="fa fa-trash pr-2"></i>Clear Dewar</button>
         </div>
     </div>
 </template>
@@ -40,10 +39,6 @@ export default {
         }
     },
     methods: {
-        clearLocation: function(location) {
-            console.log("Clear Dewar from " + location)
-            this.$emit('clear-location', location)
-        },
         showDewarReport: function(dewar) {
             console.log("Update Dewar from " + dewar.dewarId)
             this.$emit('update-dewar', dewar)

--- a/client/src/components/DewarCard.vue
+++ b/client/src/components/DewarCard.vue
@@ -5,6 +5,7 @@ Emits an event 'clear-location' which should be handled by the parent component
 -->
 <template>
     <div class="border rounded shadow h-full p-4 cursor-pointer"
+        v-on:click.prevent="showDewarReport(dewar)"
         v-bind:class="{'text-danger': dewar.needsLN2 && dewar.status !== 'dispatch-requested', 'bg-gray-400' : dewar.onBeamline}">
         <span class="font-bold">{{rack}}: </span>
         <span v-if="dewar.barcode" class="font-bold">{{dewar.barcode}}</span>
@@ -15,9 +16,6 @@ Emits an event 'clear-location' which should be handled by the parent component
             <span v-if="dewar.facilityCode" class="text-xs text-white bg-gray-900 py-1 px-2">{{dewar.facilityCode}}</span>
             <span v-if="dewar.status == 'dispatch-requested'" class="text-xs bg-warning py-1 px-2 ">{{dewar.status}}</span>
             <span v-if="dewar.needsLN2" class="text-xs text-white bg-danger py-1 px-2 ">needs-refill</span>
-        </div>
-        <div v-if="dewar.barcode" class="flex justify-between mt-2 pt-2 border-t border-gray-400">
-            <button @click.prevent="showDewarReport(dewar)" class="rounded text-sm text-gray-200 bg-green-500 hover:bg-green-700 px-2 py-1"><i :class="[buttonClass, 'pr-2']"></i>{{ buttonLabel }}</button>
         </div>
     </div>
 </template>
@@ -30,18 +28,12 @@ export default {
         dewar: Object,
         rack: String
     },
-    computed: {
-        buttonLabel: function() {
-            return this.dewar.comments ? 'Edit Report' : 'Add Report'
-        },
-        buttonClass: function() {
-            return this.dewar.comments ? 'fa fa-pencil' : 'fa fa-plus'
-        }
-    },
     methods: {
         showDewarReport: function(dewar) {
-            console.log("Update Dewar from " + dewar.dewarId)
-            this.$emit('update-dewar', dewar)
+            if (dewar.dewarId) {
+                console.log("Update Dewar from " + dewar.dewarId)
+                this.$emit('update-dewar', dewar)
+            }
         }
     }
 }

--- a/client/src/components/DewarReportDialog.vue
+++ b/client/src/components/DewarReportDialog.vue
@@ -41,7 +41,7 @@ Emits an event 'confirm-removal' with a boolean true/false if user confirmed act
             <button class="text-white bg-success hover:bg-green-700 rounded px-2 py-1 m-2" v-on:click="onSave()">Save Report</button>
             <button class="text-white bg-danger hover:bg-red-700 rounded px-2 py-1 m-2" v-on:click="onClose()">Cancel</button>
           </div>
-          <button class="rounded text-sm text-gray-200 bg-red-500 hover:bg-red-700 px-2 py-1" v-on:click.prevent="clearLocation(dewarBarcode)"><i class="fa fa-trash pr-2"></i>Clear Dewar</button>
+          <button class="text-white bg-red-700 hover:bg-red-900 rounded px-2 py-1 m-2" v-on:click.prevent="clearLocation(dewarBarcode)"><i class="fa fa-trash pr-2"></i>Clear Dewar</button>
         </footer>
       </div>
     </div>

--- a/client/src/components/DewarReportDialog.vue
+++ b/client/src/components/DewarReportDialog.vue
@@ -36,9 +36,12 @@ Emits an event 'confirm-removal' with a boolean true/false if user confirmed act
               </ul>
           </form>
         </section>
-        <footer class="flex border-t-2 justify-end">
-          <button class="text-white bg-success hover:bg-green-700 rounded px-2 py-1 m-2" v-on:click="onSave()">Save Report</button>
-          <button class="text-white bg-danger hover:bg-red-700 rounded px-2 py-1 m-2" v-on:click="onClose()">Cancel</button>
+        <footer class="flex border-t-2 justify-between">
+          <div>
+            <button class="text-white bg-success hover:bg-green-700 rounded px-2 py-1 m-2" v-on:click="onSave()">Save Report</button>
+            <button class="text-white bg-danger hover:bg-red-700 rounded px-2 py-1 m-2" v-on:click="onClose()">Cancel</button>
+          </div>
+          <button class="rounded text-sm text-gray-200 bg-red-500 hover:bg-red-700 px-2 py-1" v-on:click.prevent="clearLocation(dewarBarcode)"><i class="fa fa-trash pr-2"></i>Clear Dewar</button>
         </footer>
       </div>
     </div>
@@ -154,7 +157,11 @@ export default {
         checkLengthValid: function(comments) {
             console.log("Comments length = " + comments.length)
             return comments.length > MAX_CONTENT_LENGTH ? false : true
-        }
+        },
+        clearLocation: function(barcode) {
+            console.log("Clear Dewar " + barcode)
+            this.$emit('clear-location', barcode)
+        },
     }
 }
 </script>

--- a/client/src/components/DewarReportDialog.vue
+++ b/client/src/components/DewarReportDialog.vue
@@ -159,6 +159,7 @@ export default {
             return comments.length > MAX_CONTENT_LENGTH ? false : true
         },
         clearLocation: function(barcode) {
+            this.onClose()
             console.log("Clear Dewar " + barcode)
             this.$emit('clear-location', barcode)
         },

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -25,7 +25,6 @@
     <div v-if="zone==='zone6'" class="flex flex-wrap">
       <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
         <DewarCard
-          v-on:clear-location="onClearLocation"
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
@@ -37,7 +36,6 @@
     <div v-else-if="zone === 'zone4'" class="flex flex-wrap">
       <div class="w-full md:w-1/6 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack" >
         <DewarCard
-          v-on:clear-location="onClearLocation"
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
@@ -49,7 +47,6 @@
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
       <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
         <DewarCard 
-          v-on:clear-location="onClearLocation"
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
@@ -77,7 +74,8 @@
       v-bind:dewarBarcode="dewarBarcode"
       v-bind:dewarComments="dewarComments"
       v-bind:dewarContainers="dewarContainers"
-      v-on:confirm-update="onConfirmUpdateDewarReport">
+      v-on:confirm-update="onConfirmUpdateDewarReport"
+      v-on:clear-location="onClearLocation">
     </DewarReportDialog>
 
   </div>

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -67,7 +67,7 @@
     <ClearLocationDialog 
       v-on:confirm-removal="onConfirmClear" 
       v-bind:isActive="isRemoveDialogActive"
-      v-bind:locationToRemove="locationToRemove"
+      v-bind:barcodeToRemove="barcodeToRemove"
       v-bind:rack_locations="rack_locations">
     </ClearLocationDialog>
 
@@ -107,7 +107,7 @@ export default {
   },
   data() {
     return {
-      locationToRemove: null,
+      barcodeToRemove: null,
       isRemoveDialogActive: false,
       beamlines: [],
 
@@ -257,10 +257,10 @@ export default {
         },
         // Handler for clear location event (rack location clicked)
         // This will trigger the confirm dialog box to show up
-        onClearLocation: function(location) {
+        onClearLocation: function(barcode) {
           // This location will be upper case because we control how it is rendered
           this.isRemoveDialogActive = true
-          this.locationToRemove = location
+          this.barcodeToRemove = barcode
         },
         // User has either confirmed or cancelled
         onConfirmClear: function(confirm) {
@@ -272,7 +272,7 @@ export default {
             // window.location.reload()
           }
           // Reset data that will disable dialog box
-          this.locationToRemove = "";
+          this.barcodeToRemove = "";
           this.isRemoveDialogActive = false
         },
         // Handler for clear location event (rack location clicked)


### PR DESCRIPTION
To tidy up the interface, and to make it harder to accidentally hit "Clear Dewar", the button has been moved onto the dewar report card. As there was now only one button left on each dewar on the main page (Add/Edit Report), that button has been removed, and the whole div for the dewar brings up the report card instead.