### PR TITLE
Mark a dewar as needing LN2 topup unless it has been explicitly topped up

### DIFF
--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -42,7 +42,9 @@ def set_location(barcode, location, awb=None):
 
     if location == 'LN2TOPUP':
         dewarId = dewar_details['dewarId']
-        comments = json.loads(dewar_details['comments'])
+        comments = {}
+        if dewar_details['comments'] is not None:
+            comments = json.loads(dewar_details['comments'])
         now = datetime.strftime(datetime.now(), '%Y-%m-%dT%H:%M:%S')
         if 'toppedUp' in comments and type(comments['toppedUp']) == list:
             comments['toppedUp'].insert(0, now)

--- a/client/src/components/DispatchDewars.vue
+++ b/client/src/components/DispatchDewars.vue
@@ -10,7 +10,7 @@
                 </ul>
                 <footer class="">
                     <div class="text-center py-2">
-                        <p>(Scan dewars back into the same position after refilling)</p>
+                        <p>(Scan dewars with location LN2TOPUP after refilling)</p>
                     </div>
                 </footer>
             </section>
@@ -23,7 +23,7 @@
                 </ul>
                 <footer class="">
                     <div class="text-center py-2">
-                        <p>(Scan dewars back into the same position after refilling)</p>
+                        <p>(Scan dewars with location LN2TOPUP after refilling)</p>
                     </div>
                 </footer>
             </section>
@@ -36,7 +36,7 @@
                 </ul>
                 <footer class="">
                     <div class="text-center py-2">
-                        <p>(Scan dewars back into the same position after refilling)</p>
+                        <p>(Scan dewars with location LN2TOPUP after refilling)</p>
                     </div>
                 </footer>
             </section>
@@ -49,7 +49,7 @@
                 </ul>
                 <footer class="">
                     <div class="text-center py-2">
-                        <p>(Scan dewars back into the same position after refilling)</p>
+                        <p>(Scan dewars with location LN2TOPUP after refilling)</p>
                     </div>
                 </footer>
             </section>

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -191,7 +191,7 @@ export default {
             let onBeamline = dewarInfo.onBeamline ? dewarInfo.onBeamline : false
 
             // Check here if topup > 5 days ago (and dewar is not on beamline being processed)
-            if (dewarInfo.arrivalDate !== "" && !onBeamline) {
+            if (!onBeamline) {
               let nowSecs = new Date().getTime()/1000;
               let lastFillSeconds = 0;
               // Topups are now recorded in the comments field

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -193,11 +193,12 @@ export default {
             // Check here if topup > 5 days ago (and dewar is not on beamline being processed)
             if (dewarInfo.arrivalDate !== "" && !onBeamline) {
               let nowSecs = new Date().getTime()/1000;
+              let lastFillSeconds = 0;
               // Topups are now recorded in the comments field
               if ('comments' in dewarInfo && dewarInfo.comments != null) {
                 let dewarComments = JSON.parse(dewarInfo.comments)
                 if ('toppedUp' in dewarComments) {
-                  let lastFillSeconds = Date.parse(dewarComments.toppedUp[0])/1000
+                  lastFillSeconds = Date.parse(dewarComments.toppedUp[0])/1000
                 }
               }
 

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -191,7 +191,7 @@ export default {
             let onBeamline = dewarInfo.onBeamline ? dewarInfo.onBeamline : false
 
             // Check here if topup > 5 days ago (and dewar is not on beamline being processed)
-            if (!onBeamline) {
+            if (dewarInfo.arrivalDate !== "" && !onBeamline) {
               let nowSecs = new Date().getTime()/1000;
               let lastFillSeconds = 0;
               // Topups are now recorded in the comments field

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -191,7 +191,7 @@ export default {
             let onBeamline = dewarInfo.onBeamline ? dewarInfo.onBeamline : false
 
             // Check here if topup > 5 days ago (and dewar is not on beamline being processed)
-            if (!onBeamline) {
+            if (dewarInfo.arrivalDate !== "" && !onBeamline) {
               let nowSecs = new Date().getTime()/1000;
               // Topups are now recorded in the comments field
               if ('comments' in dewarInfo && dewarInfo.comments != null) {

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -190,18 +190,14 @@ export default {
             // Flag to indicate dewar is on beamline (and therefore space is taken)...
             let onBeamline = dewarInfo.onBeamline ? dewarInfo.onBeamline : false
 
-            // Check here if arrivalDate > 5 days ago (and dewar is not on beamline being processed)
-            if (dewarInfo.arrivalDate !== "" && !onBeamline) {
+            // Check here if topup > 5 days ago (and dewar is not on beamline being processed)
+            if (!onBeamline) {
               let nowSecs = new Date().getTime()/1000;
-              let lastFillSeconds = Date.parse(dewarInfo.arrivalDate)/1000
-              // Topups can also be recorded in the comments field
+              // Topups are now recorded in the comments field
               if ('comments' in dewarInfo && dewarInfo.comments != null) {
                 let dewarComments = JSON.parse(dewarInfo.comments)
                 if ('toppedUp' in dewarComments) {
-                  let lastTopupSeconds = Date.parse(dewarComments.toppedUp[0])/1000
-                  if (lastTopupSeconds > lastFillSeconds) {
-                    lastFillSeconds = lastTopupSeconds
-                  }
+                  let lastFillSeconds = Date.parse(dewarComments.toppedUp[0])/1000
                 }
               }
 


### PR DESCRIPTION
Ticket: [LIMS-592](https://jira.diamond.ac.uk/browse/LIMS-592)

Dewars must now be scanned at location LN2TOPUP to say they have been topped up. If not, they will be flagged as needing a topup after 5 days. Previously any scan would restart the clock.