### PR TITLE
Put last topup last

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 client/node_modules
 client/dist
 .env/
+*~

--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -45,10 +45,10 @@ def set_location(barcode, location, awb=None):
         comments = {}
         if dewar_details['comments'] is not None:
             comments = json.loads(dewar_details['comments'])
-        now = datetime.strftime(datetime.now(), '%Y-%m-%dT%H:%M:%S')
+        now = datetime.now().isoformat("T", "seconds")
         if 'toppedUp' in comments and type(comments['toppedUp']) == list:
-            comments['toppedUp'].insert(0, now)
-            comments['toppedUp'] = comments['toppedUp'][:5]
+            comments['toppedUp'].append(now)
+            comments['toppedUp'] = comments['toppedUp'][-5:]
         else:
             comments['toppedUp'] = [now]
         return update_comments(dewarId, json.dumps(comments))

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -198,7 +198,7 @@ export default {
               if ('comments' in dewarInfo && dewarInfo.comments != null) {
                 let dewarComments = JSON.parse(dewarInfo.comments)
                 if ('toppedUp' in dewarComments) {
-                  lastFillSeconds = Date.parse(dewarComments.toppedUp[0])/1000
+                  lastFillSeconds = Date.parse(dewarComments.toppedUp.slice(-1)[0])/1000
                 }
               }
 

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -198,9 +198,6 @@ export default {
               if ('comments' in dewarInfo && dewarInfo.comments != null) {
                 let dewarComments = JSON.parse(dewarInfo.comments)
                 if ('toppedUp' in dewarComments) {
-                  console.log(dewarComments.toppedUp)
-                  console.log(dewarComments.toppedUp.slice(-1))
-                  console.log(dewarComments.toppedUp.slice(-1)[0])
                   lastFillSeconds = Date.parse(dewarComments.toppedUp.slice(-1)[0])/1000
                 }
               }

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -198,6 +198,9 @@ export default {
               if ('comments' in dewarInfo && dewarInfo.comments != null) {
                 let dewarComments = JSON.parse(dewarInfo.comments)
                 if ('toppedUp' in dewarComments) {
+                  console.log(dewarComments.toppedUp)
+                  console.log(dewarComments.toppedUp.slice(-1))
+                  console.log(dewarComments.toppedUp.slice(-1)[0])
                   lastFillSeconds = Date.parse(dewarComments.toppedUp.slice(-1)[0])/1000
                 }
               }


### PR DESCRIPTION
Put LN2 topups in order they are done from first to last, rather than last to first. The stored procedure used by mx-logistics can only append, so this keep the dewar-logistics version consistent. Dewar checking is also always done first to last.