### PR TITLE
Add m02 locations and display as a separate block

### DIFF
--- a/api/dewars/ebic.py
+++ b/api/dewars/ebic.py
@@ -3,7 +3,7 @@
 #
 # # Build list of rack locations e.g. EBIC-IN-[1..27]
 rack_locations = ['EBIC-IN-{}'.format(i) for i in range(1,28)]
-extra_rack_locations = ['EBIC-M02-{}'.format(i) for i in [chr(alpha+65) for alpha in range(0,6)]]
+rack_locations.extend(['EBIC-M02-{}'.format(i) for i in [chr(alpha+65) for alpha in range(0,6)]])
 
 beamlines = ['m01',
              'm02',

--- a/api/dewars/ebic.py
+++ b/api/dewars/ebic.py
@@ -1,8 +1,9 @@
 #
 # Configuration for the Zone4 Storage Area
 #
-# # Build list of rack locations e.g. EBIC-IN-[1..20]
+# # Build list of rack locations e.g. EBIC-IN-[1..27]
 rack_locations = ['EBIC-IN-{}'.format(i) for i in range(1,28)]
+rack_locations.extend(['EBIC-M02-{}'.format(i) for i in [chr(alpha+65) for alpha in range(0,6)]])
 
 beamlines = ['m01',
              'm02',

--- a/api/dewars/ebic.py
+++ b/api/dewars/ebic.py
@@ -3,7 +3,7 @@
 #
 # # Build list of rack locations e.g. EBIC-IN-[1..27]
 rack_locations = ['EBIC-IN-{}'.format(i) for i in range(1,28)]
-rack_locations.extend(['EBIC-M02-{}'.format(i) for i in [chr(alpha+65) for alpha in range(0,6)]])
+extra_rack_locations = ['EBIC-M02-{}'.format(i) for i in [chr(alpha+65) for alpha in range(0,6)]]
 
 beamlines = ['m01',
              'm02',

--- a/api/dewars/routes.py
+++ b/api/dewars/routes.py
@@ -20,7 +20,7 @@ from . import zone6
 
 locations = {'zone6': zone6.rack_locations,
              'zone4': zone4.rack_locations,
-             'ebic': ebic.rack_locations,
+             'ebic': ebic.rack_locations + ebic.extra_rack_locations,
              }
 
 

--- a/api/dewars/routes.py
+++ b/api/dewars/routes.py
@@ -20,7 +20,7 @@ from . import zone6
 
 locations = {'zone6': zone6.rack_locations,
              'zone4': zone4.rack_locations,
-             'ebic': ebic.rack_locations + ebic.extra_rack_locations,
+             'ebic': ebic.rack_locations,
              }
 
 

--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -532,7 +532,7 @@ def is_arriving_at_ebic(location, previous_location):
     if location == previous_location:
         return False
 
-    if location.upper() in ebic.rack_locations():
+    if location.upper() in ebic.rack_locations:
         return True
 
     return False

--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -537,6 +537,11 @@ def is_arriving_at_ebic(location, previous_location):
     if match:
         result = True
 
+    expr = re.compile(r'EBIC-M02-[A-F]', re.IGNORECASE)
+    match = expr.match(location)
+    if match:
+        result = True
+
     return result
 
 def is_leaving_ebic(location):

--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -15,6 +15,8 @@ from . import webservice
 from . import send_email
 from .models import Dewar, DewarTransportHistory, LabContact, Laboratory, Shipping, Proposal, Person, BLSession, Container
 
+from ..dewars import ebic
+
 # What age do we ignore container history entries
 CONTAINER_FILTER_DAYS_LIMIT = 30
 email_domain = os.environ.get('EMAIL_DOMAIN', '@diamond.ac.uk')
@@ -530,31 +532,19 @@ def is_arriving_at_ebic(location, previous_location):
     if location == previous_location:
         return False
 
-    result = False
+    if location.upper() in ebic.rack_locations():
+        return True
 
-    expr = re.compile(r'EBIC-IN-\d', re.IGNORECASE)
-    match = expr.match(location)
-    if match:
-        result = True
-
-    expr = re.compile(r'EBIC-M02-[A-F]', re.IGNORECASE)
-    match = expr.match(location)
-    if match:
-        result = True
-
-    return result
+    return False
 
 def is_leaving_ebic(location):
     """
     Utility method to check if the location is EBIC-TO-STORES
     in which case we need to email LC
     """
-    result = False
 
-    expr = re.compile(r'EBIC-TO-STORES', re.IGNORECASE)
-    match = expr.match(location)
-    if match:
-        result = True
+    if location.upper() == 'EBIC-TO-STORES':
+        return True
 
-    return result
+    return False
 

--- a/client/src/components/ClearLocationDialog.vue
+++ b/client/src/components/ClearLocationDialog.vue
@@ -31,7 +31,7 @@ Emits an event 'confirm-removal' with a boolean true/false if user confirmed act
 <script>
 export default {
     name: 'ClearLocationDialog',
-    props: ['isActive', 'barcodeToRemove', 'rack_locations'],
+    props: ['isActive', 'barcodeToRemove', 'rack_locations', 'extra_rack_locations'],
     methods: {
         // User has confirmed to remove the dewar from this location
         onConfirm: function() {
@@ -41,8 +41,9 @@ export default {
             let barcode = this.barcodeToRemove
             let location = ""
             let loc = ""
-            for (loc in this.rack_locations) {
-                if (this.rack_locations[loc]['barcode'] == barcode) {
+            let all_locations = {...this.rack_locations, ...this.extra_rack_locations}
+            for (loc in all_locations) {
+                if (all_locations[loc]['barcode'] == barcode) {
                     location = loc
                     break
                 }

--- a/client/src/components/DispatchDewars.vue
+++ b/client/src/components/DispatchDewars.vue
@@ -113,7 +113,8 @@
 export default {
     name: 'DispatchDewars',
     props: {
-        rack_locations: Object
+        rack_locations: Object,
+        extra_rack_location: Object,
     },
     data() {
       return {
@@ -123,21 +124,21 @@ export default {
       }
     },  
     computed: {
-        // This is used to display 5 dewars that need refilling
+        // This is used to display dewars that need refilling
         // If they have dispatch requested show them anyway - SCI-10162
         refill_dewars: function() {
-            const self = this
-            let dewars = Object.keys(this.rack_locations).filter( function(rack) {
-                return self.rack_locations[rack].needsLN2 === true
+            let all_locations = {...this.rack_locations, ...this.extra_rack_locations}
+            let dewars = Object.keys(all_locations).filter( function(rack) {
+                return all_locations[rack].needsLN2 === true
             })
             return dewars
         },
 
-        // This is used to display 5 dewars that need to be dispatched
+        // This is used to display dewars that need to be dispatched
         dispatch_dewars: function() {
-            const self = this
-            let dewars = Object.keys(this.rack_locations).filter( function(rack) {
-                return self.rack_locations[rack].status === 'dispatch-requested'
+            let all_locations = {...this.rack_locations, ...this.extra_rack_locations}
+            let dewars = Object.keys(all_locations).filter( function(rack) {
+                return all_locations[rack].status === 'dispatch-requested'
             })
             return dewars
         }

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -44,15 +44,18 @@
       </div>
     </div>
 
-    <!-- Display the rack locations, four columns across If Zone 6 -->
+    <!-- Display the rack locations, four columns across If ebic -->
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
+     <div v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
+      <div v-if="rack==='EBIC-M02-A'" class="w-full"><hr class="bg-black" style="height:5px"></div>
+      <div class="w-full md:w-1/4 p-2">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
         </DewarCard>
       </div>
+     </div>
     </div>
 
     <!-- Default display if unknown location requested -->

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -53,19 +53,22 @@
           v-bind:rack="rack">
         </DewarCard>
       </div>
-      <div class="w-full"><hr class="h-1 bg-black"></div>
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar2, rack2) in extra_rack_locations" v-bind:key="rack">
-        <DewarCard 
-          v-on:update-dewar="onShowDewarReport"
-          v-bind:dewar="dewar2"
-          v-bind:rack="rack2">
-        </DewarCard>
-      </div>
     </div>
 
     <!-- Default display if unknown location requested -->
     <div v-else>
       <p>No known storage location</p>
+    </div>
+    
+    <div v-if="zone==='ebic'" class="w-full"><hr class="h-1 bg-black"></div>
+    <div v-if="zone==='ebic'" class="flex flex-wrap">
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
+        <DewarCard 
+          v-on:update-dewar="onShowDewarReport"
+          v-bind:dewar="dewar"
+          v-bind:rack="rack">
+        </DewarCard>
+      </div>
     </div>
 
 

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -60,7 +60,16 @@
       <p>No known storage location</p>
     </div>
     
-
+    <div v-if="zone==='ebic'" class="w-full"><hr class="h-1 bg-black"></div>
+    <div v-if="zone==='ebic'" class="flex flex-wrap">
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
+        <DewarCard 
+          v-on:update-dewar="onShowDewarReport"
+          v-bind:dewar="dewar"
+          v-bind:rack="rack">
+        </DewarCard>
+      </div>
+    </div>
 
 
     <!-- This pops up to confirm the clear location action -->
@@ -178,10 +187,10 @@ export default {
           this.$http.get(url).then(function(response) {
             // Re-assign rack_locations property to trigger reactivity
             // Otherwise Vue has a hard time running computed properties
-            self.rack_locations, self.extra_rack_locations = self.handleUpdateBarcodesOK(response)
+            [self.rack_locations, self.extra_rack_locations] = self.handleUpdateBarcodesOK(response)
           })
           .catch(function(error) {
-            self.rack_locations, self.extra_rack_locations = self.handleUpdateBarcodesError(error)
+            [self.rack_locations, self.extra_rack_locations] = self.handleUpdateBarcodesError(error)
           })
           console.log("self.rack_locations: ")
           console.log(self.rack_locations)
@@ -263,7 +272,7 @@ export default {
           // Return rack data
           console.log("rack_data: ")
           console.log(rack_data)
-          return rack_data, extra_rack_data
+          return [rack_data, extra_rack_data]
         },
         handleUpdateBarcodesError: function(error) {
             let message = ""
@@ -289,7 +298,7 @@ export default {
             }
             this.$store.dispatch('updateMessage', {text: message, isError: isError})
 
-            return rack_data, extra_rack_data
+            return [rack_data, extra_rack_data]
         },
         // Handler for clear location event (rack location clicked)
         // This will trigger the confirm dialog box to show up

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -62,11 +62,11 @@
     
     <div v-if="zone==='ebic'" class="w-full"><hr class="h-1 bg-black"></div>
     <div v-if="zone==='ebic'" class="flex flex-wrap">
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar2, rack2) in extra_rack_locations" v-bind:key="rack2">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
-          v-bind:dewar="dewar"
-          v-bind:rack="rack">
+          v-bind:dewar="dewar2"
+          v-bind:rack="rack2">
         </DewarCard>
       </div>
     </div>
@@ -192,6 +192,8 @@ export default {
           .catch(function(error) {
             self.rack_locations, self.extra_rack_locations = self.handleUpdateBarcodesError(error)
           })
+          console.log("self.rack_locations: ")
+          console.log(self.rack_locations)
           // Now setup the next update
           self.refresh = setTimeout(self.getBarcodes, self.refreshInterval)
         },
@@ -268,6 +270,8 @@ export default {
           })
 
           // Return rack data
+          console.log("rack_data: ")
+          console.log(rack_data)
           return rack_data, extra_rack_data
         },
         handleUpdateBarcodesError: function(error) {

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -6,13 +6,16 @@
           v-bind:allowed_locations="allowed_locations"
           v-on:dewars-updated="handleDewarUpdate"
           ref="ScanDewar">
-          </ScanDewar>
+        </ScanDewar>
       </div>
       <div class="w-full md:w-1/3 border border-solid border-black m-2">
         <FindDewar></FindDewar>
       </div>
       <div class="w-full md:w-1/3 border border-solid border-black m-2">
-        <DispatchDewars v-bind:rack_locations="rack_locations"></DispatchDewars>
+        <DispatchDewars
+          v-bind:rack_locations="rack_locations"
+          v-bind:extra_rack_locations="extra_rack_locations">
+        </DispatchDewars>
       </div>
     </div>
 
@@ -47,7 +50,7 @@
     <!-- Display the rack locations, four columns across If ebic -->
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
       <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
-        <DewarCard 
+        <DewarCard
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
@@ -59,11 +62,11 @@
     <div v-else>
       <p>No known storage location</p>
     </div>
-    
+
     <div v-if="Object.keys(extra_rack_locations).length" class="w-full"><hr class="h-1 bg-black"></div>
     <div v-if="Object.keys(extra_rack_locations).length" class="flex flex-wrap">
       <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
-        <DewarCard 
+        <DewarCard
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -60,16 +60,7 @@
       <p>No known storage location</p>
     </div>
     
-    <div v-if="zone==='ebic'" class="w-full"><hr class="h-1 bg-black"></div>
-    <div v-if="zone==='ebic'" class="flex flex-wrap">
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar2, rack2) in extra_rack_locations" v-bind:key="rack2">
-        <DewarCard 
-          v-on:update-dewar="onShowDewarReport"
-          v-bind:dewar="dewar2"
-          v-bind:rack="rack2">
-        </DewarCard>
-      </div>
-    </div>
+
 
 
     <!-- This pops up to confirm the clear location action -->

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -46,9 +46,9 @@
 
     <!-- Display the rack locations, four columns across If ebic -->
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
-     <div v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
+     <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
       <div v-if="rack==='EBIC-M02-A'" class="w-full"><hr class="h-1 bg-black"></div>
-      <div class="w-full md:w-1/4 p-2">
+      <div>
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -187,10 +187,10 @@ export default {
           this.$http.get(url).then(function(response) {
             // Re-assign rack_locations property to trigger reactivity
             // Otherwise Vue has a hard time running computed properties
-            self.rack_locations = self.handleUpdateBarcodesOK(response)
+            self.rack_locations, self.extra_rack_locations = self.handleUpdateBarcodesOK(response)
           })
           .catch(function(error) {
-            self.rack_locations = self.handleUpdateBarcodesError(error)
+            self.rack_locations, self.extra_rack_locations = self.handleUpdateBarcodesError(error)
           })
           // Now setup the next update
           self.refresh = setTimeout(self.getBarcodes, self.refreshInterval)
@@ -199,6 +199,7 @@ export default {
         handleUpdateBarcodesOK: function(response) {
           let json = response.data
           let rack_data = {} // Placeholder for new data
+          let extra_rack_data = {}
 
           let racklist = Object.keys(json)
           
@@ -233,29 +234,47 @@ export default {
               }
             }
 
-            rack_data[rack] = {
-              'dewarId': dewarInfo.dewarId,
-              'comments': dewarInfo.comments,
-              'dewarContainers': dewarInfo.dewarContainers,
-              'beamline': dewarInfo.beamline,
-              'visit': dewarInfo.visit,
-              'startDate': dewarInfo.startDate,
-              'barcode': dewarInfo.barcode,
-              'arrivalDate': dewarInfo.arrivalDate,
-              'facilityCode': dewarInfo.facilityCode,
-              'status': dewarInfo.status,
-              'needsLN2': needsLN2,
-              'onBeamline': onBeamline
+            if (rack.startsWith('EBIC-M02')) {
+              extra_rack_data[rack] = {
+                'dewarId': dewarInfo.dewarId,
+                'comments': dewarInfo.comments,
+                'dewarContainers': dewarInfo.dewarContainers,
+                'beamline': dewarInfo.beamline,
+                'visit': dewarInfo.visit,
+                'startDate': dewarInfo.startDate,
+                'barcode': dewarInfo.barcode,
+                'arrivalDate': dewarInfo.arrivalDate,
+                'facilityCode': dewarInfo.facilityCode,
+                'status': dewarInfo.status,
+                'needsLN2': needsLN2,
+                'onBeamline': onBeamline
+              }
+            } else {
+              rack_data[rack] = {
+                'dewarId': dewarInfo.dewarId,
+                'comments': dewarInfo.comments,
+                'dewarContainers': dewarInfo.dewarContainers,
+                'beamline': dewarInfo.beamline,
+                'visit': dewarInfo.visit,
+                'startDate': dewarInfo.startDate,
+                'barcode': dewarInfo.barcode,
+                'arrivalDate': dewarInfo.arrivalDate,
+                'facilityCode': dewarInfo.facilityCode,
+                'status': dewarInfo.status,
+                'needsLN2': needsLN2,
+                'onBeamline': onBeamline
+              }
             }
           })
 
           // Return rack data
-          return rack_data
+          return rack_data, extra_rack_data
         },
         handleUpdateBarcodesError: function(error) {
             let message = ""
             let isError = true
             let rack_data = {} // Placeholder for new data
+            let extra_rack_data = {}
 
             if (error.response && error.response.status === 404) {
               // No dewars found - might be true
@@ -275,7 +294,7 @@ export default {
             }
             this.$store.dispatch('updateMessage', {text: message, isError: isError})
 
-            return rack_data
+            return rack_data, extra_rack_data
         },
         // Handler for clear location event (rack location clicked)
         // This will trigger the confirm dialog box to show up

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -77,7 +77,8 @@
       v-on:confirm-removal="onConfirmClear" 
       v-bind:isActive="isRemoveDialogActive"
       v-bind:barcodeToRemove="barcodeToRemove"
-      v-bind:rack_locations="rack_locations">
+      v-bind:rack_locations="rack_locations"
+      v-bind:extra_rack_locations="extra_rack_locations">
     </ClearLocationDialog>
 
     <DewarReportDialog
@@ -201,6 +202,7 @@ export default {
           let rack_data = {} // Placeholder for new data
           let extra_rack_data = {}
           let this_rack = {}
+          let rack_prefix = null
 
           let racklist = Object.keys(json)
           
@@ -249,7 +251,8 @@ export default {
               'needsLN2': needsLN2,
               'onBeamline': onBeamline
             }
-            if (rack.startsWith('EBIC-M02')) {
+            if (!rack_prefix) {rack_prefix = rack.split("-").slice(0,-1).join("-")}
+            if (rack_prefix != rack.split("-").slice(0,-1).join("-")) {
               extra_rack_data[rack] = this_rack
             } else {
               rack_data[rack] = this_rack

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -47,7 +47,7 @@
     <!-- Display the rack locations, four columns across If ebic -->
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
      <div v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
-      <div v-if="rack==='EBIC-M02-A'" class="w-full"><hr class="bg-black" style="height:5px"></div>
+      <div v-if="rack==='EBIC-M02-A'" class="w-full"><hr class="h-1 bg-black"></div>
       <div class="w-full md:w-1/4 p-2">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -46,16 +46,21 @@
 
     <!-- Display the rack locations, four columns across If ebic -->
     <div v-else-if="zone==='ebic'" class="flex flex-wrap">
-     <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
-      <div v-if="rack==='EBIC-M02-A'" class="w-full"><hr class="h-1 bg-black"></div>
-      <div>
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
           v-bind:rack="rack">
         </DewarCard>
       </div>
-     </div>
+      <div class="w-full"><hr class="h-1 bg-black"></div>
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
+        <DewarCard 
+          v-on:update-dewar="onShowDewarReport"
+          v-bind:dewar="dewar"
+          v-bind:rack="rack">
+        </DewarCard>
+      </div>
     </div>
 
     <!-- Default display if unknown location requested -->

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -54,7 +54,7 @@
         </DewarCard>
       </div>
       <div class="w-full"><hr class="h-1 bg-black"></div>
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in rack_locations" v-bind:key="rack">
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
           v-bind:dewar="dewar"
@@ -122,6 +122,7 @@ export default {
       beamlines: [],
 
       rack_locations: {},
+      extra_rack_locations: {},
       // Timeout handle - used to determine if we need to refresh page
       refresh: null,
       refreshInterval: 60000, // refresh interval in milliseconds

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -200,7 +200,7 @@ export default {
           let json = response.data
           let rack_data = {} // Placeholder for new data
           let extra_rack_data = {}
-          let rack_prefix = null
+          let this_rack = {}
 
           let racklist = Object.keys(json)
           
@@ -280,6 +280,7 @@ export default {
               console.log("Caught 503 Service unavailable...")
             } else {
               message = "Error retrieving dewar location information from database"
+              console.log(error)
             }
             this.$store.dispatch('updateMessage', {text: message, isError: isError})
 

--- a/client/src/views/Dewars.vue
+++ b/client/src/views/Dewars.vue
@@ -54,11 +54,11 @@
         </DewarCard>
       </div>
       <div class="w-full"><hr class="h-1 bg-black"></div>
-      <div class="w-full md:w-1/4 p-2" v-for="(dewar, rack) in extra_rack_locations" v-bind:key="rack">
+      <div class="w-full md:w-1/4 p-2" v-for="(dewar2, rack2) in extra_rack_locations" v-bind:key="rack">
         <DewarCard 
           v-on:update-dewar="onShowDewarReport"
-          v-bind:dewar="dewar"
-          v-bind:rack="rack">
+          v-bind:dewar="dewar2"
+          v-bind:rack="rack2">
         </DewarCard>
       </div>
     </div>


### PR DESCRIPTION
- Add locations EBIC-M02-[A-F]
- Use the list of EBIC racks rather than a separate regex to detect dewars arriving at ebic
- Create concept of extra rack locations, those where the prefix changes (anything before the last hyphen)
- Display those after a horizontal bar to create separation
- Pass those extra dewar locations around to allow clearing, flagging for topup/dispatch
- Fix a few comments