### PR TITLE
LN2TOPUP barcode should not be case sensitive

### DIFF
--- a/api/ispyb_api/controller.py
+++ b/api/ispyb_api/controller.py
@@ -42,7 +42,7 @@ def set_location(barcode, location, awb=None):
     dewar_details = get_dewar_by_barcode(actual_barcode)
     previous_location = dewar_details['storageLocation']
 
-    if location == 'LN2TOPUP':
+    if location.upper() == 'LN2TOPUP':
         dewarId = dewar_details['dewarId']
         comments = {}
         if dewar_details['comments'] is not None:


### PR DESCRIPTION
Scanning a dewar with `LN2TOPUP` adds a message saying it has been topped up, but scanning to `ln2topup` moves it to the location `ln2topup`. This is to fix that.